### PR TITLE
Added initial storage buffer support - draft

### DIFF
--- a/ghengin-core/ghengin-core-indep/Ghengin/Core/Shader/Data.hs
+++ b/ghengin-core/ghengin-core-indep/Ghengin/Core/Shader/Data.hs
@@ -33,9 +33,9 @@ class Block ty => ShaderData ty where
 
   -- | The primitive FIR shader type whose memory representation matches the result
   -- of serializing this datatype using 'Poke'. This is the promise that if
-  -- your shader expects @FirType ty@ in a uniform location, writing @ty@ into the
-  -- buffer will be sound, and the shader will find @ty@'s laid out in memory
-  -- according to @FirType ty@'s expected memory layout.
+  -- your shader expects @FirType ty@ in a uniform/storage location, writing @ty@
+  -- into the buffer will be sound, and the shader will find @ty@'s laid out 
+  -- in memory according to @FirType ty@'s expected memory layout.
   --
   -- === _Example_
   --

--- a/ghengin-core/ghengin-core-indep/Ghengin/Core/Type/Compatible.hs
+++ b/ghengin-core/ghengin-core-indep/Ghengin/Core/Type/Compatible.hs
@@ -172,7 +172,7 @@ type family DSetBinding (set :: Nat) (binding :: Nat) (info :: PipelineInfo) :: 
 type family DSetBinding' (set :: Nat) (binding :: Nat) (info :: PipelineInfo) :: Type where
   DSetBinding' set binding info =
     FromMaybe (DSetBinding set binding info)
-              (TypeError (Text "Uniform [Descriptor Set #" :<>: ShowType set :<>: Text ", Binding #" :<>: ShowType binding :<>: Text "] not found in " :<>: ShowType info))
+              (TypeError (Text "Descriptor [Descriptor Set #" :<>: ShowType set :<>: Text ", Binding #" :<>: ShowType binding :<>: Text "] not found in " :<>: ShowType info))
 
 type family FindDSetInput (set :: Nat) (binding :: Nat) (inputs :: [TLInterfaceVariable]) :: Maybe Type where
   FindDSetInput set binding '[] = 'Nothing

--- a/ghengin-core/ghengin-core.cabal
+++ b/ghengin-core/ghengin-core.cabal
@@ -180,7 +180,7 @@ library backend-independent-bits
                       -- TODO: NOT DEPEND ON VULKAN IN CORE INDEP
                       vulkan,
                       linear-base,
-                      reference-counting,
+                      reference-counting >= 0.2.0.0,
 
                       template-haskell,
                       containers,
@@ -237,7 +237,7 @@ library vulkan
                       vulkan,
                       GLFW-b,
                       linear-base,
-                      reference-counting,
+                      reference-counting >= 0.2.0.0,
                       -- ghengin-core MISTAKE!(#23322, could we depend on ghengin-core for non-indefinite modules only?)
                       ghengin-core:backend-independent-bits,
                       gl-block,

--- a/ghengin-core/ghengin-core/Ghengin/Core/Render.hs
+++ b/ghengin-core/ghengin-core/Ghengin/Core/Render.hs
@@ -28,9 +28,10 @@ import qualified Data.Linear.Alias as Alias
 
 -- I don't know where exactly to put this, so put it here for now
 getDescriptorResource :: ResourceMap ⊸ Int -> Renderer (DescriptorResource, ResourceMap)
-getDescriptorResource resourcemap i = enterD "getUniformBuffer" $
+getDescriptorResource resourcemap i = enterD "getDescriptorResource" $
   IM.lookupM i resourcemap >>= \case
     (Just x, rmap1) -> pure (x, rmap1)
     (Nothing, rmap1) -> Linear.do
       Alias.forget rmap1
-      error $ "Expecting a uniform descriptor resource at binding " <> show i <> " but found nothing!"
+      error $ "Expecting a descriptor resource at binding " <> show i <> " but found nothing!"
+

--- a/ghengin-core/ghengin-core/Ghengin/Core/Renderer/Buffer.hsig
+++ b/ghengin-core/ghengin-core/Ghengin/Core/Renderer/Buffer.hsig
@@ -13,7 +13,7 @@ import Graphics.Gl.Block
 {-
 Note [Mapped vs Device-local Buffers]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Mapped buffers are buffers of usage 'UNIFORM' (as in uniform buffer) which are
+Mapped buffers are buffers of e.g. usage 'UNIFORM' (as in uniform buffer) which are
 mapped to a device-local buffer. Writing to a mapped buffer writes host-local
 memory which is synchronized automatically to the device-local memory.
 
@@ -31,7 +31,7 @@ Note [Block vs Storable]
 ~~~~~~~~~~~~~~~~~~~~~~~~
 We use `Block` constraint when we can make the call about which layout to use down the line.
 For MappedBuffer, the (for now) only constructor is Uniform buffer. When
-writing into uniform buffers we know what layout to use (std140).
+writing into mapped buffers we know what layout to use (std140).
 
 However, for `DeviceLocalBuffer`s, at the moment, we don't know its use, so we
 delegate the decision of what standard to use to the definition site of the
@@ -75,11 +75,14 @@ destroyDeviceLocalBuffer :: DeviceLocalBuffer ⊸ Renderer ()
 
 -------- Mapped Buffer -----------------
 
--- | A mapped (uniform) buffer. See Note [Mapped vs Device-local Buffers]
+-- | A mapped (uniform/storage) buffer. See Note [Mapped vs Device-local Buffers]
 data MappedBuffer
 
+-- | Type of buffer (e.g. uniform, storage)
+data BufferType = Uniform | Storage
+
 -- | TODO: Drop dependency on Vulkan and make DescriptorType a data type renderer agnostic
-createMappedBuffer :: Word -> Vk.DescriptorType -> Renderer (Alias MappedBuffer)
+createMappedBuffer :: Word -> BufferType -> Renderer (Alias MappedBuffer)
 writeMappedBuffer :: ∀ α. Block α => Alias MappedBuffer ⊸ α -> Renderer (Alias MappedBuffer)
 
 

--- a/ghengin-core/ghengin-core/Ghengin/Core/Renderer/DescriptorSet.hsig
+++ b/ghengin-core/ghengin-core/Ghengin/Core/Renderer/DescriptorSet.hsig
@@ -8,6 +8,8 @@ import Ghengin.Core.Renderer.Kernel
 import Ghengin.Core.Renderer.Buffer
 import Ghengin.Core.Renderer.Texture
 
+import qualified Vulkan as Vk (DescriptorType, ShaderStageFlags)
+
 -------- Resources ----------------
 -- Resources are a part of the descriptor set module since these resources are
 -- used to manipulate the descriptors of the descriptor set.
@@ -17,12 +19,19 @@ import Ghengin.Core.Renderer.Texture
 
 type ResourceMap = IntMap DescriptorResource
 
-
 data DescriptorResource where
   UniformResource   :: Alias MappedBuffer ⊸ DescriptorResource
+  StorageResource   :: Alias MappedBuffer ⊸ DescriptorResource
   Texture2DResource :: Alias Texture2D ⊸ DescriptorResource
 instance Forgettable Renderer DescriptorResource
 instance Shareable m DescriptorResource
+
+-- | TODO: Drop dependency on Vulkan
+type BindingsMap = IntMap (Vk.DescriptorType, Vk.ShaderStageFlags)
+
+type DescriptorSetMap = IntMap BindingsMap
+
+createDescriptorSetBindingsMap :: ShaderPipeline info -> Ur DescriptorSetMap
 
 -- ROMES:TODO: These definitions need to be inlined... in the instancing modules?
 -- Shouldn't be too inefficient since the use case, ResourceMap, is usually small
@@ -38,7 +47,7 @@ instance Shareable m DescriptorResource
 
 data DescriptorPool
 
-createDescriptorPool :: ShaderPipeline info
+createDescriptorPool :: DescriptorSetMap
                      -> Renderer DescriptorPool
 
 

--- a/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer.hs
+++ b/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer.hs
@@ -130,8 +130,6 @@ runRenderer dimensions r = Linear.do
 
   pure a
 
-
-
 -- | Run a 'Renderer' action that depends on a command buffer and the current
 -- image index of the swapchain to typically by writing to the command buffer
 -- the draw calls (to the renderpasse's framebuffer responsible for that

--- a/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/Buffer.hs-boot
+++ b/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/Buffer.hs-boot
@@ -26,6 +26,6 @@ data DeviceLocalBuffer where
 
 -------- Mapped Buffer -----------------
 
--- | A mapped (uniform) buffer. See Note [Mapped vs Device-local Buffers]
+-- | A mapped (e.g. uniform) buffer. See Note [Mapped vs Device-local Buffers]
 data MappedBuffer
 

--- a/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/DescriptorSet.hs-boot
+++ b/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/DescriptorSet.hs-boot
@@ -8,7 +8,7 @@ type BindingsMap = IntMap (Vk.DescriptorType, Vk.ShaderStageFlags)
 
 data DescriptorPool =
   DescriptorPool { dpool :: Vk.DescriptorPool
-                 , set_bindings :: IntMap (Vk.DescriptorSetLayout, BindingsMap)
+                 , set_bindings :: IntMap Vk.DescriptorSetLayout
                  }
 
 data DescriptorSet

--- a/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/Pipeline.hs
+++ b/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/Pipeline.hs
@@ -131,7 +131,7 @@ createGraphicsPipeline  ::
                          ⊸ RenderPass
                          ⊸ Renderer (RenderPass, (RendererPipeline Graphics, DescriptorPool))
 createGraphicsPipeline gps ppstages pushConstantRanges = Unsafe.toLinearN @2 \dpool renderP -> enterD "createGraphicsPipeline" $ Linear.do
-  Ur descriptorSetLayouts <- liftSystemIOU $ Prelude.pure $ V.fromList $ Prelude.fmap (Prelude.fst) (IM.elems dpool.set_bindings)
+  Ur descriptorSetLayouts <- liftSystemIOU $ Prelude.pure $ V.fromList $ IM.elems dpool.set_bindings
 
   Ur dev <- unsafeGetDevice
 


### PR DESCRIPTION
In my game, I need to insert a 100x100 Int32 grid into the shader. This is too large for Uniform buffers, so I added Storage Buffer support.

I implemented this by adding a parameter to Dynamic & Static bindings, which is a sum type of either Uniform or Storage. Later push constants can be added also this way.

This is just a draft, I still need to update the documentation. I also need to do some more testing.

Do you have any thoughts on this approach? 

I was thinking that perhaps the binding type (Uniform or Storage) should be inferred from the FIR type, but as far as I can tell that type is only used as a sanity check against what's defined in Ghengin. That is, it's only checked against and not used to inform Ghengin of the pipeline structure.