### PR TITLE
Added Vertex Vec2 lift instance

### DIFF
--- a/ghengin-core/ghengin-core-indep/Ghengin/Core/Mesh/Vertex.hs
+++ b/ghengin-core/ghengin-core-indep/Ghengin/Core/Mesh/Vertex.hs
@@ -15,6 +15,7 @@ import Language.Haskell.TH.Syntax
 
 -- for orphan instances while they aren't upstreamed
 import Geomancy.Vec3
+import Geomancy.Vec2
 
 
 -- ROMES:TODO: It turns out alignment for Vertices is even something else entirely!!!
@@ -129,3 +130,7 @@ instance (Lift (Vertex (y : xs)), Lift x) => Lift (Vertex (x : y : xs)) where
 instance Lift Vec3 where
     lift (WithVec3 a b c) = [| vec3 $(lift a) $(lift b) $(lift c) |]
     liftTyped (WithVec3 a b c) = [|| vec3 $$(liftTyped a) $$(liftTyped b) $$(liftTyped c) ||]
+
+instance Lift Vec2 where
+    lift (WithVec2 a b) = [| vec2 $(lift a) $(lift b) |]
+    liftTyped (WithVec2 a b) = [|| vec2 $$(liftTyped a) $$(liftTyped b) ||]


### PR DESCRIPTION
I wanted to send Vec2 vertices to the GPU recently and had to add this.

Perhaps this is wrong in some way?