### PR TITLE
Add debug option to write out spirv after compiling shaders

### DIFF
--- a/ghengin-core/ghengin-core.cabal
+++ b/ghengin-core/ghengin-core.cabal
@@ -36,6 +36,7 @@ common common-flags
         -DDEBUG
         -- -DDEBUG_TRACE
         -- -DTHINGS_ARE_GOING_THAT_BAD
+        -- -DDEBUG_WRITE_SHADERS
 
   else
     ghc-options: -O2 -threaded
@@ -131,6 +132,7 @@ library
                       reference-counting >= 0.2.0.0,
                       os-string,
                       text >= 0.2,
+                      temporary,
 
                       template-haskell,
                       stm, async,
@@ -242,6 +244,7 @@ library vulkan
                       -- ghengin-core MISTAKE!(#23322, could we depend on ghengin-core for non-indefinite modules only?)
                       ghengin-core:backend-independent-bits,
                       gl-block,
+                      temporary,
 
                       -- For textures (consider adding to Core too)
                       JuicyPixels,


### PR DESCRIPTION
Sometimes I have a need to look at the shaders FIR generates.

This adds an option to do that.

It's a bit crude in that:

- It adds a whole new dependency on `random`
- The file names it writes to are all randomized
  + But what could it possibly be named, since the shader can live in many separate Haskell files? 
  + Perhaps I should simply name them sequentially, although they will be overwritten each run that way, but that could also happen if the random function was unlucky and generated the same name twice.
  + Naming them sequentially would complicate the code earlier, as I would need to pass in which N shader is being compiled.
- It writes to /tmp/ and not PWD. Writing to PWD is dangerous, as it might overwrite something perhaps, and it's usually a mess in my experience. 
  + Is /tmp/ a standard directory on Mac also? I suppose this would cause issues on Windows. 
  + I think best would be to use the `getTemporaryDirectory` function from the directory package. https://hackage.haskell.org/package/directory-1.3.9.0/docs/System-Directory.html#v:getTemporaryDirectory
  + But that would add another dependency. Is that fine?

Thoughts?