### PR TITLE
Refactor: Remove Core monad

### DIFF
--- a/examples/book-of-shaders/shaping-functions/Main.hs
+++ b/examples/book-of-shaders/shaping-functions/Main.hs
@@ -23,11 +23,11 @@ import Shaders
 --  https://www.saschawillems.de/blog/2016/08/13/vulkan-tutorial-on-rendering-a-fullscreen-quad-without-buffers/
 --------------------------------------------------------------------------------
 
-gameLoop :: Alias RenderPass ⊸ RenderQueue () ⊸ Core (RenderQueue ())
+gameLoop :: Alias RenderPass ⊸ RenderQueue () ⊸ Renderer (RenderQueue ())
 gameLoop rp rq = Linear.do
- should_close <- (shouldCloseWindow ↑)
- if should_close then (Alias.forget rp ↑) >> return rq else Linear.do
-  (pollWindowEvents ↑)
+ should_close <- shouldCloseWindow
+ if should_close then Alias.forget rp >> return rq else Linear.do
+  pollWindowEvents
 
   (rp, rq) <- renderWith $ Linear.do
 
@@ -48,16 +48,16 @@ gameLoop rp rq = Linear.do
 main :: Prelude.IO ()
 main = do
  withLinearIO $
-  runCore (width, height) Linear.do
+  runRenderer (width, height) Linear.do
 
-    (rp1, rp2) <- (Alias.share =<< createSimpleRenderPass ↑)
+    (rp1, rp2) <- Alias.share =<< createSimpleRenderPass
 
-    pipeline      <- (makeRenderPipelineWith defaultGraphicsPipelineSettings{cullMode=CullBack} rp1 shaderPipelineSimple GHNil ↑)
+    pipeline      <- makeRenderPipelineWith defaultGraphicsPipelineSettings{cullMode=CullBack} rp1 shaderPipelineSimple GHNil
     (rq, Ur pkey) <- pure (insertPipeline pipeline LMon.mempty)
 
     rq <- gameLoop rp2 rq
 
-    (freeRenderQueue rq ↑)
+    freeRenderQueue rq
 
     return (Ur ())
 

--- a/examples/book-of-shaders/shaping-functions/Shaders.hs
+++ b/examples/book-of-shaders/shaping-functions/Shaders.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wno-missing-local-signatures #-}
+{-# OPTIONS_GHC -Wno-missing-local-signatures -Wno-missing-signatures #-}
 
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE BlockArguments        #-}
@@ -81,6 +81,6 @@ fragmentSimple = shader do
   #out_colour .= Vec4 r g b 1
 
   where
-    f1 x = x ** 5
+    f1 p = p ** 5
     f2 = smoothstep 0.1 0.9
-    f3 x = sin (2*pi*x) / 2 + 0.5
+    f3 p = sin (2*pi*p) / 2 + 0.5

--- a/examples/book-of-shaders/uniforms/Main.hs
+++ b/examples/book-of-shaders/uniforms/Main.hs
@@ -23,11 +23,11 @@ import Shaders
 --  https://www.saschawillems.de/blog/2016/08/13/vulkan-tutorial-on-rendering-a-fullscreen-quad-without-buffers/
 --------------------------------------------------------------------------------
 
-gameLoop :: Alias RenderPass ⊸ RenderQueue () ⊸ Core (RenderQueue ())
+gameLoop :: Alias RenderPass ⊸ RenderQueue () ⊸ Renderer (RenderQueue ())
 gameLoop rp rq = Linear.do
- should_close <- (shouldCloseWindow ↑)
- if should_close then (Alias.forget rp ↑) >> return rq else Linear.do
-  (pollWindowEvents ↑)
+ should_close <- shouldCloseWindow
+ if should_close then Alias.forget rp >> return rq else Linear.do
+  pollWindowEvents
 
   (rp, rq) <- renderWith $ Linear.do
 
@@ -48,16 +48,16 @@ gameLoop rp rq = Linear.do
 main :: Prelude.IO ()
 main = do
  withLinearIO $
-  runCore (width, height) Linear.do
+  runRenderer (width, height) Linear.do
 
-    (rp1, rp2) <- (Alias.share =<< createSimpleRenderPass ↑)
+    (rp1, rp2) <- Alias.share =<< createSimpleRenderPass
 
-    pipeline      <- (makeRenderPipelineWith defaultGraphicsPipelineSettings{cullMode=CullFront} rp1 shaderPipelineSimple GHNil ↑)
+    pipeline      <- makeRenderPipelineWith defaultGraphicsPipelineSettings{cullMode=CullFront} rp1 shaderPipelineSimple GHNil
     (rq, Ur pkey) <- pure (insertPipeline pipeline LMon.mempty)
 
     rq <- gameLoop rp2 rq
 
-    (freeRenderQueue rq ↑)
+    freeRenderQueue rq
 
     return (Ur ())
 

--- a/examples/dear-imgui/Main.hs
+++ b/examples/dear-imgui/Main.hs
@@ -23,11 +23,11 @@ import qualified Ghengin.DearImGui.Vulkan as ImGui
 --  https://www.saschawillems.de/blog/2016/08/13/vulkan-tutorial-on-rendering-a-fullscreen-quad-without-buffers/
 --------------------------------------------------------------------------------
 
-gameLoop :: Alias RenderPass ⊸ RenderQueue () ⊸ Core (RenderQueue ())
+gameLoop :: Alias RenderPass ⊸ RenderQueue () ⊸ Renderer (RenderQueue ())
 gameLoop rp rq = Linear.do
- should_close <- (shouldCloseWindow ↑)
- if should_close then (Alias.forget rp ↑) >> return rq else Linear.do
-  (pollWindowEvents ↑)
+ should_close <- shouldCloseWindow
+ if should_close then Alias.forget rp >> return rq else Linear.do
+  pollWindowEvents
 
   -- Prepare Imgui data
   ImGui.withNewFrame $ do
@@ -55,21 +55,21 @@ gameLoop rp rq = Linear.do
 main :: Prelude.IO ()
 main = do
  withLinearIO $
-  runCore (width, height) Linear.do
+  runRenderer (width, height) Linear.do
 
-    (rp1, rp2) <- (Alias.share =<< createSimpleRenderPass ↑)
+    (rp1, rp2) <- Alias.share =<< createSimpleRenderPass
 
     -- Init imgui
-    (rp1, imctx) <- (Alias.useM rp1 ImGui.initImGui ↑)
+    (rp1, imctx) <- Alias.useM rp1 ImGui.initImGui
 
-    pipeline      <- (makeRenderPipelineWith defaultGraphicsPipelineSettings{cullMode=CullFront} rp1 shaderPipelineSimple GHNil ↑)
+    pipeline      <- makeRenderPipelineWith defaultGraphicsPipelineSettings{cullMode=CullFront} rp1 shaderPipelineSimple GHNil
     (rq, Ur pkey) <- pure (insertPipeline pipeline LMon.mempty)
 
     rq <- gameLoop rp2 rq
 
-    (freeRenderQueue rq ↑)
+    freeRenderQueue rq
     -- Then destroy it
-    (ImGui.destroyImCtx imctx ↑)
+    ImGui.destroyImCtx imctx
 
     return (Ur ())
 

--- a/examples/fir-juliaset/Main.hs
+++ b/examples/fir-juliaset/Main.hs
@@ -87,7 +87,7 @@ gameLoop (WithVec2 previousPosX previousPosY) pkey rq = Linear.do
 main :: Prelude.IO ()
 main = do
  withLinearIO $
-  runCore WINDOW_SIZE Linear.do
+  runRenderer WINDOW_SIZE Linear.do
     pipeline             <- (makeMainPipeline ↑)
     -- perhaps we should allow a way to bind meshes without materials? no! they
     -- have to be compatible, and it turns out in this shader pipeline every

--- a/examples/mandlebrot-set/Main.hs
+++ b/examples/mandlebrot-set/Main.hs
@@ -87,7 +87,7 @@ gameLoop (WithVec2 previousPosX previousPosY) pkey rq = Linear.do
 main :: Prelude.IO ()
 main = do
  withLinearIO $
-  runCore WINDOW_SIZE Linear.do
+  runRenderer WINDOW_SIZE Linear.do
     pipeline             <- (makeMainPipeline ↑)
     -- perhaps we should allow a way to bind meshes without materials? no! they
     -- have to be compatible, and it turns out in this shader pipeline every

--- a/examples/ocean-waves/Main.hs
+++ b/examples/ocean-waves/Main.hs
@@ -69,7 +69,7 @@ gameLoop pkey lastTime rq = Linear.do
 main :: Prelude.IO ()
 main = do
  withLinearIO $
-  runCore WINDOW_SIZE Linear.do
+  runRenderer WINDOW_SIZE Linear.do
     (rq, Ur pkey) <- (renderQueueWithViewport shaderPipeline ↑)
     Ur now <- liftSystemIOU getCurrentTime
 

--- a/examples/oscilloscope/Main.hs
+++ b/examples/oscilloscope/Main.hs
@@ -64,7 +64,7 @@ gameLoop pkey rp rq = Linear.do
 main :: Prelude.IO ()
 main = do
  withLinearIO $
-  runCore (720, 720) Linear.do
+  runRenderer (720, 720) Linear.do
 
     (rp1, rp2) <- (Alias.share =<< createRenderPassFromSettings RenderPassSettings{keepColor = True} ↑)
 

--- a/examples/planets-core/Planet/UI.hs
+++ b/examples/planets-core/Planet/UI.hs
@@ -4,14 +4,10 @@ module Planet.UI where
 -- ToDo: introduce UI management abstraction in the
 -- not-yet-existent:unrestricted-ghengin-monad which wraps Core.
 
-import qualified Prelude as Base
 import qualified Data.IORef as Base
 import qualified Control.Monad as Base
-import Ghengin.Core
 import Ghengin.Core.Prelude as Linear
 import Ghengin.Core.Render
-import Ghengin.Core.Render.Pipeline
-import Ghengin.Core.Render.Queue
 
 import qualified Ghengin.DearImGui.Vulkan as ImGui
 import Ghengin.DearImGui.UI
@@ -22,7 +18,7 @@ import Planet
 -- always create a function: @forall a. a -> Core (Ur (a, Bool))@, where the
 -- result is the new value of type @a@ and the bool indicates whether it has
 -- changed. See `Widget`
-preparePlanetUI :: Planet -> Core (Ur (Planet, Bool, Bool))
+preparePlanetUI :: Planet -> Renderer (Ur (Planet, Bool, Bool))
 preparePlanetUI Planet{..} = Linear.do
 
   Ur changedShapeRef   <- liftIO (newIORef False)

--- a/examples/simple-triangle/Main.hs
+++ b/examples/simple-triangle/Main.hs
@@ -41,11 +41,11 @@ triangleVertices =
   , Sin $ vec3 0.5 0.5 0.1
   ]
 
-gameLoop :: Alias RenderPass ⊸ RenderQueue () ⊸ Core (RenderQueue ())
+gameLoop :: Alias RenderPass ⊸ RenderQueue () ⊸ Renderer (RenderQueue ())
 gameLoop rp rq = Linear.do
- should_close <- (shouldCloseWindow ↑)
- if should_close then (Alias.forget rp ↑) >> return rq else Linear.do
-  (pollWindowEvents ↑)
+ should_close <- shouldCloseWindow
+ if should_close then Alias.forget rp >> return rq else Linear.do
+  pollWindowEvents
 
   (rp, rq) <- render rp rq
 
@@ -54,22 +54,22 @@ gameLoop rp rq = Linear.do
 main :: Prelude.IO ()
 main = do
  withLinearIO $
-  runCore (640, 480) Linear.do
-    (rp1, rp2) <- (Alias.share =<< createSimpleRenderPass ↑)
+  runRenderer (640, 480) Linear.do
+    (rp1, rp2) <- Alias.share =<< createSimpleRenderPass
 
-    pipeline <- (makeRenderPipeline rp1 shaderPipelineSimple GHNil ↑)
-    (emptyMat, pipeline) <- (material GHNil pipeline ↑)
-    (mesh, pipeline) <- (createMesh pipeline GHNil triangleVertices ↑)
+    pipeline <- makeRenderPipeline rp1 shaderPipelineSimple GHNil
+    (emptyMat, pipeline) <- material GHNil pipeline
+    (mesh, pipeline) <- createMesh pipeline GHNil triangleVertices
     (rq, Ur pkey)    <- pure (insertPipeline pipeline LMon.mempty)
     (rq, Ur mkey)    <- pure (insertMaterial pkey emptyMat rq)
     (rq, Ur mshkey)  <- pure (insertMesh mkey mesh rq)
 
     rq <- gameLoop rp2 rq
 
-    (freeRenderQueue rq ↑)
+    freeRenderQueue rq
 
     -- In fact, freeing these again is a type error. Woho!
-    -- (destroyRenderPipeline pipeline ↑)
+    -- destroyRenderPipeline pipeline
 
     return (Ur ())
 

--- a/examples/teapot-obj/Main.hs
+++ b/examples/teapot-obj/Main.hs
@@ -30,15 +30,15 @@ import Shaders
 main :: Prelude.IO ()
 main = do
  withLinearIO $
-  runCore (640, 480) Linear.do
+  runRenderer (640, 480) Linear.do
 
-    (rp1, rp2) <- (Alias.share =<< createSimpleRenderPass ↑)
+    (rp1, rp2) <- Alias.share =<< createSimpleRenderPass
 
-    pipeline <- (makeRenderPipelineWith defaultGraphicsPipelineSettings{cullMode=CullFront, polygonMode=PolygonFill} rp1 shaderPipeline (StaticBinding (Ur camera) :## GHNil) ↑)
-    (emptyMat, pipeline) <- (material GHNil pipeline ↑)
-    (mesh, pipeline) <- (loadObjMesh "examples/teapot-obj/assets/teapot.obj" pipeline
+    pipeline <- makeRenderPipelineWith defaultGraphicsPipelineSettings{cullMode=CullFront, polygonMode=PolygonFill} rp1 shaderPipeline (StaticBinding (Ur camera) :## GHNil)
+    (emptyMat, pipeline) <- material GHNil pipeline
+    (mesh, pipeline) <- loadObjMesh "examples/teapot-obj/assets/teapot.obj" pipeline
     -- (mesh, pipeline) <- (loadObjMesh "examples/teapot-obj/assets/building-tower.obj" pipeline
-                          (DynamicBinding (Ur (scale 1.2)) :## GHNil) ↑)
+                          (DynamicBinding (Ur (scale 1.2)) :## GHNil)
 
     let !(rq, Ur pkey) = insertPipeline pipeline LMon.mempty
     (rq, Ur mkey)    <- pure (insertMaterial pkey emptyMat rq)
@@ -46,22 +46,21 @@ main = do
 
     rq <- gameLoop mshkey rp2 rq
 
-    (freeRenderQueue rq ↑)
+    (freeRenderQueue rq)
 
     return (Ur ())
 
 gameLoop :: MeshKey _ _ _ _ '[Transform] -- ^ rq key to cube mesh
          -> Alias RenderPass
           ⊸ RenderQueue ()
-          ⊸ Core (RenderQueue ())
+          ⊸ Renderer (RenderQueue ())
 gameLoop mkey rp rq = Linear.do
- should_close <- (shouldCloseWindow ↑)
- if should_close then (Alias.forget rp ↑) >> return rq else Linear.do
-  (pollWindowEvents ↑)
+ should_close <- shouldCloseWindow
+ if should_close then Alias.forget rp >> return rq else Linear.do
+  pollWindowEvents
 
   (rp, rq) <- render rp rq
-  rq <- (editMeshes mkey rq (traverse' $ propertyAt @0 (\(Ur tr) -> pure $ Ur $
-    rotateY 0.01 <> tr)) ↑)
+  rq <- editMeshes mkey rq (traverse' $ propertyAt @0 (\(Ur tr) -> pure $ Ur $ rotateY 0.01 <> tr))
 
   gameLoop mkey rp rq
 

--- a/ghengin-core/ghengin-core-indep/Ghengin/Core/Log.hs
+++ b/ghengin-core/ghengin-core-indep/Ghengin/Core/Log.hs
@@ -13,7 +13,7 @@ module Ghengin.Core.Log
 import Data.Bifunctor
 import Ghengin.Core.Prelude as G
 import System.Log.FastLogger
-import qualified Prelude (take, return)
+import qualified Prelude (take, cycle)
 
 
 #ifdef THINGS_ARE_GOING_THAT_BAD
@@ -49,7 +49,7 @@ log :: (ToLogStr msg, HasLogger m) => msg -> m ()
 {-# INLINE log #-}
 log msg = getLogger >>= \(Ur logger) -> G.do
   let -- Log with preceeding unicode symbols
-      leading_syms = Prelude.take (logger._depth*2) (cycle ['│',' '])
+      leading_syms = Prelude.take (logger._depth*2) (Prelude.cycle ['│',' '])
       full_msg = toLogStr leading_syms <> toLogStr msg <> toLogStr "\n"
   liftSystemIO $
 #ifndef THINGS_ARE_GOING_THAT_BAD

--- a/ghengin-core/ghengin-core/Ghengin/Core/Render/Queue.hs
+++ b/ghengin-core/ghengin-core/Ghengin/Core/Render/Queue.hs
@@ -246,15 +246,15 @@ freeRenderQueue :: RenderQueue ()
                  ⊸ Renderer ()
 freeRenderQueue (RenderQueue rq) = Linear.do
   -- For every pipeline
-  pipesunit <- DL.traverse (\(Some2 @RenderPipeline @π @bs pipeline, materials) -> enterD "Freeing pipeline" Linear.do
+  pipesunit <- DL.traverse (\(Some2 @RenderPipeline @_π @_bs pipeline, materials) -> enterD "Freeing pipeline" Linear.do
 
     -- For every material...
-    matsunits <- DL.traverse (\(Some @Material @ms material, meshes) -> enterD "Freeing material" Linear.do
+    matsunits <- DL.traverse (\(Some @Material @_ms material, meshes) -> enterD "Freeing material" Linear.do
 
       -- For all meshes...
       meshunits <- DL.traverse (\meshes' -> Linear.do
         -- For every mesh with the same id...
-        meshunits' <- DL.traverse (\(Some2 @Mesh @ts mesh, ()) -> enterD "Freeing mesh" Linear.do
+        meshunits' <- DL.traverse (\(Some2 @Mesh @_ts mesh, ()) -> enterD "Freeing mesh" Linear.do
           freeMesh mesh
           ) meshes' -- a list of meshes with the same id
         pure (consume meshunits')

--- a/ghengin-core/ghengin-core/Ghengin/Core/Renderer.hsig
+++ b/ghengin-core/ghengin-core/Ghengin/Core/Renderer.hsig
@@ -27,10 +27,8 @@ runRenderer :: (Int, Int)
             -- ^ Dimensions of the window to render on (width, height)
             -> Renderer a ⊸ Linear.IO a
 
--- extremely contrived? not anymore (at least no longer using the transformer thing, since we no longer mix render packets with things like the ECS system s.t. this function had to be run in ECS context)!
-withCurrentFramePresent :: Int -- ^ Current frame index
-                        -> ( CommandBuffer
-                              ⊸ Int -- ^ Current image index
+withCurrentFramePresent :: ( CommandBuffer
+                              ⊸ Int -- ^ Current frame index
                              -> Renderer (a, CommandBuffer)
                            )
                          ⊸ Renderer a

--- a/ghengin-core/ghengin-core/Ghengin/Core/Renderer/Kernel.hsig
+++ b/ghengin-core/ghengin-core/Ghengin/Core/Renderer/Kernel.hsig
@@ -35,30 +35,7 @@ instance HasLogger Renderer
 type MAX_FRAMES_IN_FLIGHT_T :: Nat
 type MAX_FRAMES_IN_FLIGHT_T = 2
 
--- Inlined in instancing module... (make GHC support hsig definitions!)
--- We need this for Apecs (it requires an instance of Base's MonadIO!)
--- The worry is instancing all the Monad interface -- it's very unsafe!, as it might make us misuse
--- Renderer... even so, its better than forking Apecs at the moment
--- Or is it?
---
--- Here's another idea: define a module Ghengin.Apecs which wraps Apecs calls
--- with linear types by unsafely coercing between @Renderer a@ and a new
--- @UnrestrictedRenderer a@. It's cool that the representation of Renderer and
--- UnrestrictedRenderer are the same, since IO and StateT are defined as their
--- linear variants, just without linear types!
---
--- instance Base.Functor Renderer
--- instance Base.Applicative Renderer
--- instance Base.Monad Renderer
--- instance Base.MonadIO Renderer
-  -- Base.liftIO :: Base.IO a -> Renderer a
-  -- Base.liftIO x = liftSystemIO x
-
-
--- ROMES:TODO: really, we should be able to share this definition.
--- The limitation is backpack. Fix this one day in GHC
 renderer :: (RendererEnv ⊸ System.IO.Linear.IO (a, RendererEnv)) ⊸ Renderer a
--- renderer f = Renderer (StateT f)
 
 getRenderExtent :: Renderer (Ur Vk.Extent2D)
 

--- a/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/Buffer.hs
+++ b/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/Buffer.hs
@@ -226,7 +226,7 @@ unmapMemory :: Vk.DeviceMemory
              ⊸ Ptr ()
              -- ^ The pointer to the mapped region on the CPU
              ⊸ Renderer Vk.DeviceMemory
-unmapMemory = Unsafe.toLinear2 $ \stgMem hostMem -> enterD "unmapMemory" $ Linear.do
+unmapMemory = Unsafe.toLinear2 $ \stgMem _hostMem -> enterD "unmapMemory" $ Linear.do
   unsafeUseDevice $ \device -> Vk.unmapMemory device stgMem
   -- Host mem is not returned because it becomes unavailable after unmapping.
   pure stgMem

--- a/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/Pipeline.hs
+++ b/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/Pipeline.hs
@@ -370,6 +370,7 @@ destroyShaderModule = Unsafe.toLinear2 \d sm -> d <$ liftSystemIO (Vk.destroySha
 -- Pipeline configuration
 --------------------------------------------------------------------------------
 
+colorBlendAttachment :: BlendMode -> Vk.PipelineColorBlendAttachmentState
 colorBlendAttachment BlendNone = (colorBlendAttachment BlendAdd){Vk.blendEnable = False}
 colorBlendAttachment BlendAdd =
   Vk.PipelineColorBlendAttachmentState

--- a/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/Texture.hs
+++ b/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/Texture.hs
@@ -105,13 +105,13 @@ newTexture img sampler' =
     (stagingBuffer, image) <- immediateSubmit $ Linear.do
 
       -- (1) 
-      image <- transitionImageLayout image (imagePixelFormat img) Vk.IMAGE_LAYOUT_UNDEFINED Vk.IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL
+      image <- transitionImageLayout image Vk.IMAGE_LAYOUT_UNDEFINED Vk.IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL
 
       -- (2)
       (stagingBuffer, image) <- copyFullBufferToImage stagingBuffer image (imageExtent img)
 
       -- (3)
-      (image) <- transitionImageLayout image (imagePixelFormat img) Vk.IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL Vk.IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+      (image) <- transitionImageLayout image Vk.IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL Vk.IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
 
       pure (stagingBuffer, image)
 


### PR DESCRIPTION
I realize that the Core monad is more annoying than it is a useful abstraction. The frameCounter it currently holds can be simply moved inside of the Renderer. All the lifting to  Core from Renderer doesn't give you any benefits but is quite annoying.

I laid out a roadmap in issue#30 detailing how I envision some things going forward. And why a `Core` layer is unnecessary between the linear `Renderer` and an eventual `Ghengin` monad over.

It also includes some refactors and cleanups all around.

Fixes #30