### PR TITLE
Implemented instancing support & exposed all draw options to user

### DIFF
--- a/examples/common/Common.hs
+++ b/examples/common/Common.hs
@@ -88,9 +88,9 @@ renderQueueWithViewport sp = Linear.do
     -- perhaps we should allow a way to bind meshes without materials? no! they
     -- have to be compatible, and it turns out in this shader pipeline every
     -- empty material is compatible. this explicitness is good...
-    (emptyMat, pipeline) <- material GHNil pipeline
-    (mesh, pipeline)     <- createMeshWithIxs pipeline GHNil viewportVertices viewportIndices
-    (rq, Ur pkey)        <- pure (insertPipeline pipeline LMon.mempty)
-    (rq, Ur mkey)        <- pure (insertMaterial pkey emptyMat rq)
-    (rq, Ur mshkey)      <- pure (insertMesh mkey mesh rq)
+    (emptyMat, pipeline)   <- material GHNil pipeline
+    (mesh, pipeline, Ur _) <- createMeshWithIxs pipeline GHNil viewportVertices viewportIndices
+    (rq, Ur pkey)          <- pure (insertPipeline pipeline LMon.mempty)
+    (rq, Ur mkey)          <- pure (insertMaterial pkey emptyMat rq)
+    (rq, Ur mshkey)        <- pure (insertMesh mkey mesh rq)
     return (rq, Ur pkey)

--- a/examples/fir-juliaset/Main.hs
+++ b/examples/fir-juliaset/Main.hs
@@ -91,11 +91,11 @@ main = do
     -- perhaps we should allow a way to bind meshes without materials? no! they
     -- have to be compatible, and it turns out in this shader pipeline every
     -- empty material is compatible. this explicitness is good...
-    (emptyMat, pipeline) <- (material GHNil pipeline ↑)
-    (mesh, pipeline)     <- (createMeshWithIxs pipeline GHNil viewportVertices viewportIndices ↑)
-    (rq, Ur pkey)        <- pure (insertPipeline pipeline LMon.mempty)
-    (rq, Ur mkey)        <- pure (insertMaterial pkey emptyMat rq)
-    (rq, Ur mshkey)      <- pure (insertMesh mkey mesh rq)
+    (emptyMat, pipeline)   <- (material GHNil pipeline ↑)
+    (mesh, pipeline, Ur _) <- (createMeshWithIxs pipeline GHNil viewportVertices viewportIndices ↑)
+    (rq, Ur pkey)          <- pure (insertPipeline pipeline LMon.mempty)
+    (rq, Ur mkey)          <- pure (insertMaterial pkey emptyMat rq)
+    (rq, Ur mshkey)        <- pure (insertMesh mkey mesh rq)
 
     Ur (x,y) <- (getMousePos ↑)
     rq <- gameLoop (vec2 (double2Float x) (double2Float y)) pkey rq

--- a/examples/full-pipeline/Main.hs
+++ b/examples/full-pipeline/Main.hs
@@ -92,7 +92,7 @@ main =
 
     pipeline :: RenderPipeline π ps <- makeRenderPipeline rp1 shaderPipeline (StaticBinding (Ur (cameraLookAt @"view" @"proj" (vec3 0 0 0) (vec3 0 0 1) (640, 480))) :## GHNil)
     (emptyMat, pipeline) <- material GHNil pipeline
-    (mesh :: IcosahedronMesh, pipeline) <- createMeshWithIxs pipeline GHNil icosahedronVerts icosahedronIndices
+    (mesh :: IcosahedronMesh, pipeline, Ur _) <- createMeshWithIxs pipeline GHNil icosahedronVerts icosahedronIndices
 
     (rq, Ur pkey)    <- pure (insertPipeline @π @ps pipeline LMon.mempty)
     (rq, Ur mkey)    <- pure (insertMaterial @π @ps pkey emptyMat rq)

--- a/examples/function-plotting/Main.hs
+++ b/examples/function-plotting/Main.hs
@@ -143,10 +143,10 @@ main = do
      (rp1, rp2) <- Alias.share =<< createSimpleRenderPass
      pipeline <- makeRenderPipeline rp1 (shader f) pipeline_props
      (emptyMat, pipeline) <- material GHNil pipeline
-     (gridMeshX, pipeline) <- createMesh pipeline grid_props (gridVertsX width height)
-     (gridMeshY, pipeline) <- createMesh pipeline grid_props (gridVertsY width height)
-     (axisMesh, pipeline) <- createMesh pipeline axis_props (axisVerts width height)
-     (functionMesh, pipeline) <- createMesh pipeline line_props verts
+     (gridMeshX, pipeline, Ur _) <- createMesh pipeline grid_props (gridVertsX width height)
+     (gridMeshY, pipeline, Ur _) <- createMesh pipeline grid_props (gridVertsY width height)
+     (axisMesh, pipeline, Ur _) <- createMesh pipeline axis_props (axisVerts width height)
+     (functionMesh, pipeline, Ur _) <- createMesh pipeline line_props verts
      (rq, Ur pkey)    <- pure (insertPipeline pipeline LMon.mempty)
      (rq, Ur mkey)    <- pure (insertMaterial pkey emptyMat rq)
      (rq, Ur _gmk)    <- pure (insertMesh mkey gridMeshX rq)
@@ -157,7 +157,7 @@ main = do
      (rp3, rp4) <- Alias.share rp2
      pipeline2 <- makeRenderPipeline rp3 (shader weierstrass) pipeline_props
      (emptyMat, pipeline2) <- material GHNil pipeline2
-     (functionMesh, pipeline2) <- createMesh pipeline2 line_props verts
+     (functionMesh, pipeline2, Ur _) <- createMesh pipeline2 line_props verts
      (rq, Ur pkey2)    <- pure (insertPipeline pipeline2 rq)
      (rq, Ur mkey2)    <- pure (insertMaterial pkey2 emptyMat rq)
      (rq, Ur _)        <- pure (insertMesh mkey2 functionMesh rq)

--- a/examples/lorenz-attractor/Main.hs
+++ b/examples/lorenz-attractor/Main.hs
@@ -80,7 +80,7 @@ main = do
                    rp1 shaderPipeline (StaticBinding (Ur myCamera) :## GHNil)
     (emptyMat, pipeline) <- material GHNil pipeline
 
-    (mesh :: Points, pipeline) <-
+    (mesh :: Points, pipeline, Ur _) <-
       createMesh pipeline GHNil start_points
 
     (rq, Ur pkey)    <- pure (insertPipeline pipeline LMon.mempty)

--- a/examples/mandlebrot-set/Main.hs
+++ b/examples/mandlebrot-set/Main.hs
@@ -92,7 +92,7 @@ main = do
     -- have to be compatible, and it turns out in this shader pipeline every
     -- empty material is compatible. this explicitness is good...
     (emptyMat, pipeline) <- (material GHNil pipeline ↑)
-    (mesh, pipeline)     <- (createMeshWithIxs pipeline GHNil viewportVertices viewportIndices ↑)
+    (mesh, pipeline, Ur _)     <- (createMeshWithIxs pipeline GHNil viewportVertices viewportIndices ↑)
     (rq, Ur pkey)        <- pure (insertPipeline pipeline LMon.mempty)
     (rq, Ur mkey)        <- pure (insertMaterial pkey emptyMat rq)
     (rq, Ur mshkey)      <- pure (insertMesh mkey mesh rq)

--- a/examples/planets-core/Planet.hs
+++ b/examples/planets-core/Planet.hs
@@ -131,7 +131,7 @@ newPlanetMesh rp Planet{..} = Linear.do
 
       minmax = MinMax (P.minimum elevations) (P.maximum elevations)
 
-   in (, Ur minmax) <$> createMeshWithIxsSV rp (DynamicBinding (Ur mempty) :## GHNil) (V.convert planetVs) (SV.map fromIntegral is)
+   in (\(a, b, Ur _) -> (a, b), Ur minmax) <$> createMeshWithIxsSV rp (DynamicBinding (Ur mempty) :## GHNil) (V.convert planetVs) (SV.map fromIntegral is)
 
 --------------------------------------------------------------------------------
 -- * Material

--- a/examples/simple-camera/Main.hs
+++ b/examples/simple-camera/Main.hs
@@ -80,7 +80,7 @@ main = do
     (rp1, rp2) <- Alias.share =<< createSimpleRenderPass
     pipeline <- makeRenderPipeline rp1 shaderPipeline (StaticBinding (Ur defaultCamera) :## GHNil)
     (emptyMat, pipeline) <- material GHNil pipeline
-    (mesh :: CubeMesh, pipeline) <-
+    (mesh :: CubeMesh, pipeline, Ur _) <-
       -- Also displays how TH can be used to create procedural meshes at compile time when the parameters are statically known
       createMesh pipeline (DynamicBinding (Ur (rotateY (pi/4))) :## GHNil) ($$(TH.liftTyped coloredCube))
     (rq, Ur pkey)    <- pure (insertPipeline pipeline LMon.mempty)

--- a/examples/simple-cube/Main.hs
+++ b/examples/simple-cube/Main.hs
@@ -116,7 +116,7 @@ main = do
 
     (emptyMat, pipeline) <- material GHNil pipeline
 
-    (mesh :: CubeMesh, pipeline) <-
+    (mesh :: CubeMesh, pipeline, Ur _) <-
       createMesh pipeline (DynamicBinding (Ur (rotateX (pi/4))) :## GHNil) cubeVertices
 
     (rq, Ur pkey)    <- pure (insertPipeline pipeline LMon.mempty)

--- a/examples/simple-triangle-colored/Main.hs
+++ b/examples/simple-triangle-colored/Main.hs
@@ -43,11 +43,11 @@ main = do
     (rp1, rp2) <- Alias.share =<< createSimpleRenderPass
 
     pipeline <- makeRenderPipeline rp1 shaderPipelineColors GHNil
-    (emptyMat, pipeline) <- material GHNil pipeline
-    (mesh, pipeline) <- createMeshWithIxs pipeline GHNil triangleVerticesWithColors [0, 1, 2]
-    (rq, Ur pkey)    <- pure (insertPipeline pipeline LMon.mempty)
-    (rq, Ur mkey)    <- pure (insertMaterial pkey emptyMat rq)
-    (rq, Ur mshkey)  <- pure (insertMesh mkey mesh rq)
+    (emptyMat, pipeline)   <- material GHNil pipeline
+    (mesh, pipeline, Ur _) <- createMeshWithIxs pipeline GHNil triangleVerticesWithColors [0, 1, 2]
+    (rq, Ur pkey)          <- pure (insertPipeline pipeline LMon.mempty)
+    (rq, Ur mkey)          <- pure (insertMaterial pkey emptyMat rq)
+    (rq, Ur mshkey)        <- pure (insertMesh mkey mesh rq)
 
     rq <- gameLoop rp2 rq
 

--- a/examples/simple-triangle/Main.hs
+++ b/examples/simple-triangle/Main.hs
@@ -46,7 +46,7 @@ main = do
 
     pipeline <- makeRenderPipeline rp1 shaderPipelineSimple GHNil
     (emptyMat, pipeline) <- material GHNil pipeline
-    (mesh, pipeline) <- createMesh pipeline GHNil triangleVertices
+    (mesh, pipeline, Ur _) <- createMesh pipeline GHNil triangleVertices
     (rq, Ur pkey)    <- pure (insertPipeline pipeline LMon.mempty)
     (rq, Ur mkey)    <- pure (insertMaterial pkey emptyMat rq)
     (rq, Ur mshkey)  <- pure (insertMesh mkey mesh rq)

--- a/ghengin-core/ghengin-core-indep/Ghengin/Core/Shader/Data.hs
+++ b/ghengin-core/ghengin-core-indep/Ghengin/Core/Shader/Data.hs
@@ -163,8 +163,37 @@ instance (KnownNat n, Storable x, Block x) => Block (V n x) where
   writePacked = write140
 
 instance (KnownNat n, Block x, Storable x) => ShaderData (V n x) where
-  type FirType (V n x) = V n x
+  type FirType (V n x) = V n (FirType x)
 
+-- FIR Array
+-- It's a newtype of the FIR Vector. It differs in that it generates different SPIRV code, allowing for types such as 'Array 50 (M 4 4 Float)', which Vectors don't support (as they only support scalars, meaning Float, Int, etc, not complex types)
+-- See the 'layoutable' function in FIR.Layout for more information, as well as the SPIRV docs for Array
+-- WARNING: Because the layoutable function seems to has some funky alignment code depending for arrays, deriving the storable instance of Vector like this might not be correct, but it seems to work fine.
+deriving anyclass instance (Generic a) => Generic (FIR.Array n a)
+deriving newtype instance (Storable a, KnownNat n) => Storable (FIR.Array n a)
+
+instance (KnownNat n, Storable x, Block x) => Block (FIR.Array n x) where
+  type PackedSize (FIR.Array n x) = n * (PackedSize x)
+  isStruct _ = False
+
+  alignment140 _ = Store.alignment (undefined :: FIR.Array n x)
+  alignment430 = alignment140
+
+  sizeOf140 _ = Store.sizeOf (undefined :: FIR.Array n x)
+  sizeOf430 = sizeOf140
+  sizeOfPacked = sizeOf140
+
+  read140 p o = liftIO $ peekDiffOff p o
+  read430 = read140
+  readPacked = read140
+
+  write140 p o a = liftIO $ pokeDiffOff p o a
+  write430 = write140
+  writePacked = write140
+
+instance (KnownNat n, Storable x, Block x) => ShaderData (FIR.Array n x) where
+  type FirType (FIR.Array n x) = FIR.Array n (FirType x)
+  
 -- FIR Matrix
 instance (KnownNat m, KnownNat n, Storable x, Block x) => Block (M m n x) where
   type PackedSize (M m n x) = m * n * (PackedSize x)
@@ -186,4 +215,4 @@ instance (KnownNat m, KnownNat n, Storable x, Block x) => Block (M m n x) where
   writePacked = write140
 
 instance (KnownNat m, KnownNat n, Block x, Storable x) => ShaderData (M m n x) where
-  type FirType (M m n x) = M m n x
+  type FirType (M m n x) = M m n (FirType x)

--- a/ghengin-core/ghengin-core/Ghengin/Core.hs
+++ b/ghengin-core/ghengin-core/Ghengin/Core.hs
@@ -296,12 +296,12 @@ writePropertiesToResources rmap' fi
 
 renderMesh :: (Functor m, MonadIO m) => Mesh vs a ⊸ RenderPassCmdM m (Mesh vs a)
 renderMesh = \case
-  SimpleMesh vb ds uq -> Linear.do
-    vb' <- drawVertexBuffer vb
-    return $ SimpleMesh vb' ds uq
-  IndexedMesh vb ib ds uq -> Linear.do
-    (vb', ib') <- drawVertexBufferIndexed vb ib
-    return $ IndexedMesh vb' ib' ds uq
+  SimpleMesh vb ds uq opt -> Linear.do
+    vb' <- drawVertexBuffer opt vb
+    return $ SimpleMesh vb' ds uq opt
+  IndexedMesh vb ib ds uq opt -> Linear.do
+    (vb', ib') <- drawVertexBufferIndexed opt vb ib
+    return $ IndexedMesh vb' ib' ds uq opt
   MeshProperty p xs -> MeshProperty p <$> renderMesh xs
 
 getGraphicsPipeline :: ∀ α info. RenderPipeline info α ⊸ (RendererPipeline Graphics, RendererPipeline Graphics ⊸ RenderPipeline info α)

--- a/ghengin-core/ghengin-core/Ghengin/Core/Mesh.hs
+++ b/ghengin-core/ghengin-core/Ghengin/Core/Mesh.hs
@@ -13,10 +13,14 @@ module Ghengin.Core.Mesh
 
   , meshId
 
+  , simpleMeshOptsDef
+  , indexedMeshOptsDef
+
   -- * Vertices
   , module Ghengin.Core.Mesh.Vertex
   ) where
 
+import Ghengin.Core.Renderer.Command (SimpleMeshOpts(..), IndexedMeshOpts(..))
 import Ghengin.Core.Prelude as Linear
 import Data.Unique
 
@@ -51,11 +55,13 @@ data Mesh ts props where
                 -- , vertices :: Vector Vertex
               ⊸ (Alias DescriptorSet, Alias ResourceMap) -- ^ Descriptors for property bindings
               ⊸ !Unique
+             -> IORef SimpleMeshOpts
              -> Mesh ts '[]
   IndexedMesh :: !VertexBuffer -- ^ vertexBuffer, a vector of vertices in buffer format
                ⊸ !Index32Buffer
                ⊸ (Alias DescriptorSet, Alias ResourceMap) -- ^ Descriptors for property bindings
                ⊸ !Unique
+              -> IORef IndexedMeshOpts
               -> Mesh ts '[]
   MeshProperty :: forall p vs ps
                 . PropertyBinding p
@@ -66,8 +72,8 @@ meshId :: Mesh ts props ⊸ (Ur Unique, Mesh ts props)
 meshId = \case
   MeshProperty p xs -> case meshId xs of
     (uq, xs') -> (uq, MeshProperty p xs')
-  SimpleMesh vb ds uq -> (Ur uq, SimpleMesh vb ds uq)
-  IndexedMesh vb ib ds uq -> (Ur uq, IndexedMesh vb ib ds uq)
+  SimpleMesh vb ds uq opt -> (Ur uq, SimpleMesh vb ds uq opt)
+  IndexedMesh vb ib ds uq opt -> (Ur uq, IndexedMesh vb ib ds uq opt)
 
 instance HasProperties (Mesh vs) where
   properties :: Mesh vs ps ⊸ Renderer (PropertyBindings ps, Mesh vs ps)
@@ -76,18 +82,18 @@ instance HasProperties (Mesh vs) where
       (p1, p2) <- Alias.share p0
       (xs', mesh') <- properties xs
       pure (p1 :## xs', MeshProperty p2 mesh')
-    SimpleMesh a b c -> pure (GHNil, SimpleMesh a b c)
-    IndexedMesh a b c d -> pure (GHNil, IndexedMesh a b c d)
+    SimpleMesh a b c d -> pure (GHNil, SimpleMesh a b c d)
+    IndexedMesh a b c d e -> pure (GHNil, IndexedMesh a b c d e)
 
   descriptors = \case
-    SimpleMesh vb (ds0, rm0) uq -> Linear.do
+    SimpleMesh vb (ds0, rm0) uq opt -> Linear.do
       (ds1, ds2) <- Alias.share ds0
       (rm1, rm2) <- Alias.share rm0
-      pure (ds1, rm1, SimpleMesh vb (ds2, rm2) uq)
-    IndexedMesh vb ib (ds0, rm0) uq -> Linear.do
+      pure (ds1, rm1, SimpleMesh vb (ds2, rm2) uq opt)
+    IndexedMesh vb ib (ds0, rm0) uq opt -> Linear.do
       (ds1, ds2) <- Alias.share ds0
       (rm1, rm2) <- Alias.share rm0
-      pure (ds1, rm1, IndexedMesh vb ib (ds2, rm2) uq)
+      pure (ds1, rm1, IndexedMesh vb ib (ds2, rm2) uq opt)
     MeshProperty p xs -> Linear.do
       (dset, rmap, mesh') <- descriptors xs
       pure (dset, rmap, MeshProperty p mesh')
@@ -96,6 +102,21 @@ instance HasProperties (Mesh vs) where
   pcons = MeshProperty
 
       -- TODO: Various kinds of meshes: indexed meshes, strip meshes, just triangles...
+
+simpleMeshOptsDef = SimpleMeshOpts {
+  vertexCount = Nothing
+  , firstVertex = 0
+  , instanceCount = 1
+  , firstInstance = 0
+  }
+
+indexedMeshOptsDef = IndexedMeshOpts {
+  indexCount = Nothing
+  , firstIndex = 0
+  , instanceCount = 1
+  , firstInstance = 0
+  , vertexOffset = 0
+  }
 
 -- | Create a 'Mesh' given a list of 'Vertex's, where each 'Vertex' has a set
 -- of properties of types @ts@ (e.g. a Vec3 for position and a Vec3 for color).
@@ -117,24 +138,25 @@ createMesh :: (CompatibleMesh props π, CompatibleVertex ts π, Storable (Vertex
             -- ^ The 'PropertyBindings' for the properties of this mesh (the second type argument to 'Mesh')
             ⊸ [Vertex ts]
             -- ^ Vertices
-           -> Renderer (Mesh ts props, RenderPipeline π bs)
+           -> Renderer (Mesh ts props, RenderPipeline π bs, Ur (IORef SimpleMeshOpts))
 createMesh a b c = createMeshSV a b (SV.fromList c)
 
 -- | Like 'createMesh', but takes a storable vector directly rather than a list.
 createMeshSV
   :: (CompatibleMesh props π, CompatibleVertex ts π, Storable (Vertex ts))
   => RenderPipeline π bs ⊸ PropertyBindings props ⊸ SV.Vector (Vertex ts)
-  -> Renderer (Mesh ts props, RenderPipeline π bs)
-createMeshSV (RenderProperty pr rps) props0 vs = createMeshSV rps props0 vs >>= \case (m, rp) -> pure (m, RenderProperty pr rp)
+  -> Renderer (Mesh ts props, RenderPipeline π bs, Ur (IORef SimpleMeshOpts))
+createMeshSV (RenderProperty pr rps) props0 vs = createMeshSV rps props0 vs >>= \case (m, rp, opt) -> pure (m, RenderProperty pr rp, opt)
 createMeshSV (RenderPipeline gpip rpass (rdset, rres, (Ur bmap), dpool0) shaders uq) props0 vs = enterD "createMesh" Linear.do
+  (Ur opt) <- liftIO $ newIORef simpleMeshOptsDef
   Ur uniq      <- liftSystemIOU newUnique
   vertexBuffer <- createVertexBuffer vs
 
   (dset0, rmap0, dpool1, props1) <- allocateDescriptorsForMeshes bmap dpool0 props0
 
-  pure ( mkMesh (SimpleMesh vertexBuffer (dset0, rmap0) uniq) props1
+  pure ( mkMesh (SimpleMesh vertexBuffer (dset0, rmap0) uniq opt) props1
        , RenderPipeline gpip rpass (rdset, rres, (Ur bmap), dpool1) shaders uq
-       )
+       , Ur opt )
 
 -- | Like 'createMesh', but create the mesh using a vertex buffer created from
 -- the vertices and an indexbuffer created from the indices
@@ -154,25 +176,26 @@ createMeshWithIxs :: (CompatibleMesh props π, CompatibleVertex ts π, Storable 
                   -- ^ Vertices
                   -> [Int32]
                   -- ^ Indices
-                  -> Renderer (Mesh ts props, RenderPipeline π bs)
+                  -> Renderer (Mesh ts props, RenderPipeline π bs, Ur (IORef IndexedMeshOpts))
 createMeshWithIxs a b c d = createMeshWithIxsSV a b (SV.fromList c) (SV.fromList d)
 
 createMeshWithIxsSV
   :: (CompatibleMesh props π, CompatibleVertex ts π, Storable (Vertex ts))
   => RenderPipeline π bs ⊸ PropertyBindings props
    ⊸ SV.Vector (Vertex ts) -> SV.Vector Int32
-  -> Renderer (Mesh ts props, RenderPipeline π bs)
-createMeshWithIxsSV (RenderProperty pr rps) props0 vs ixs = createMeshWithIxsSV rps props0 vs ixs >>= \case (m, rp) -> pure (m, RenderProperty pr rp)
+  -> Renderer (Mesh ts props, RenderPipeline π bs, Ur (IORef IndexedMeshOpts))
+createMeshWithIxsSV (RenderProperty pr rps) props0 vs ixs = createMeshWithIxsSV rps props0 vs ixs >>= \case (m, rp, opt) -> pure (m, RenderProperty pr rp, opt)
 createMeshWithIxsSV (RenderPipeline gpip rpass (rdset, rres, (Ur bmap), dpool0) shaders uq) props0 vertices ixs = enterD "createMeshWithIxs" Linear.do
+  (Ur opt) <- liftIO $ newIORef indexedMeshOptsDef
   Ur uniq      <- liftSystemIOU newUnique
   vertexBuffer <- createVertexBuffer vertices
   indexBuffer  <- createIndex32Buffer ixs
 
   (dset0, rmap0, dpool1, props1) <- allocateDescriptorsForMeshes bmap dpool0 props0
 
-  pure ( mkMesh (IndexedMesh vertexBuffer indexBuffer (dset0, rmap0) uniq) props1
+  pure ( mkMesh (IndexedMesh vertexBuffer indexBuffer (dset0, rmap0) uniq opt) props1
        , RenderPipeline gpip rpass (rdset, rres, (Ur bmap), dpool1) shaders uq
-       )
+       , Ur opt )
 
 mkMesh :: ∀ t b. Mesh t '[] ⊸ PropertyBindings b ⊸ Mesh t b
 mkMesh x GHNil = x
@@ -208,9 +231,9 @@ freeMesh :: Mesh vs ps ⊸ Renderer ()
 freeMesh mesh = Linear.do
   logD "Freeing mesh..."
   case mesh of
-    SimpleMesh (VertexBuffer vb _) ds _ ->
+    SimpleMesh (VertexBuffer vb _) ds _ _ ->
       Alias.forget ds >> destroyDeviceLocalBuffer vb
-    IndexedMesh (VertexBuffer vb _) (Index32Buffer ib _) ds _ ->
+    IndexedMesh (VertexBuffer vb _) (Index32Buffer ib _) ds _ _ ->
       Alias.forget ds >> destroyDeviceLocalBuffer vb >> destroyDeviceLocalBuffer ib
     MeshProperty prop xs ->
       Alias.forget prop >> freeMesh xs

--- a/ghengin-core/ghengin-core/Ghengin/Core/Renderer/Command.hsig
+++ b/ghengin-core/ghengin-core/Ghengin/Core/Renderer/Command.hsig
@@ -1,3 +1,4 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 signature Ghengin.Core.Renderer.Command where
 
 import Ghengin.Core.Prelude
@@ -45,6 +46,22 @@ instance Linear.MonadIO m     => Linear.MonadIO (RenderPassCmdM m)
 instance HasLogger m          => HasLogger (RenderPassCmdM m)
 instance Linear.MonadTrans RenderPassCmdM
 
+data SimpleMeshOpts = SimpleMeshOpts {
+  -- Nothing means use the vertex count of the mesh
+  vertexCount :: Maybe Word32
+  , firstVertex :: Word32
+  , instanceCount :: Word32
+  , firstInstance :: Word32
+  }
+
+data IndexedMeshOpts = IndexedMeshOpts {
+  indexCount :: Maybe Word32
+  , firstIndex :: Word32
+  , instanceCount :: Word32
+  , firstInstance :: Word32
+  , vertexOffset :: Int32
+  }
+
 -- the command buffer comes from the leaky
 recordCommand :: Linear.MonadIO m => Int {-^ Current frame index -} -> CommandBuffer ⊸ CommandM m a ⊸ m (a, CommandBuffer)
 
@@ -52,10 +69,10 @@ renderPassCmd :: Linear.MonadIO m => Vk.Extent2D -> Alias.Alias m RenderPass ⊸
 
 -- TODO: Cleanup the API
 
-drawVertexBuffer :: Linear.MonadIO m => VertexBuffer ⊸ RenderPassCmdM m VertexBuffer
-drawVertexBufferIndexed :: Linear.MonadIO m => VertexBuffer ⊸ Index32Buffer ⊸ RenderPassCmdM m (VertexBuffer, Index32Buffer)
-draw :: Linear.MonadIO m => Word32 -> RenderPassCmd m
-drawIndexed :: Linear.MonadIO m => Word32 -> RenderPassCmd m
+drawVertexBuffer :: Linear.MonadIO m => IORef SimpleMeshOpts -> VertexBuffer ⊸ RenderPassCmdM m VertexBuffer
+drawVertexBufferIndexed :: Linear.MonadIO m => IORef IndexedMeshOpts -> VertexBuffer ⊸ Index32Buffer ⊸ RenderPassCmdM m (VertexBuffer, Index32Buffer)
+draw :: Linear.MonadIO m => Word32 -> Word32 -> Word32 -> Word32 -> RenderPassCmd m
+drawIndexed :: Linear.MonadIO m => Word32 -> Word32 -> Word32 -> Word32 -> Int32 -> RenderPassCmd m
 
 bindGraphicsPipeline :: Linear.MonadIO m => RendererPipeline Graphics ⊸ RenderPassCmdM m (RendererPipeline Graphics)
 

--- a/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/Command.hs
+++ b/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/Command.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UnicodeSyntax #-}
 {-# LANGUAGE BlockArguments #-}
@@ -58,12 +59,16 @@ module Ghengin.Vulkan.Renderer.Command
   , unsafeCmd_
   , unsafeRenderPassCmd
   , unsafeRenderPassCmd_
+  , SimpleMeshOpts(..)
+  , IndexedMeshOpts(..)
   ) where
 
 import GHC.TypeLits
 
+import Data.IORef
+
 import Prelude hiding (($), pure, return)
-import Prelude.Linear (($))
+import Prelude.Linear (($), Ur(..), fromMaybe)
 import qualified Prelude.Linear as Linear ((.))
 
 import qualified Data.V.Linear as V
@@ -82,6 +87,8 @@ import qualified Data.Vector as Vector
 import qualified Vulkan.CStruct.Extends as Vk
 import qualified Vulkan.Zero as Vk
 import qualified Vulkan      as Vk
+
+import Data.Int (Int32)
 
 import Ghengin.Vulkan.Renderer.Device
 import {-# SOURCE #-} Ghengin.Vulkan.Renderer.RenderPass
@@ -293,12 +300,12 @@ bindIndex32Buffer :: Linear.MonadIO m
 bindIndex32Buffer ibuffer offset = unsafeRenderPassCmd ibuffer (\buf ibuf -> Vk.cmdBindIndexBuffer buf ibuf offset Vk.INDEX_TYPE_UINT32)
 {-# INLINE bindIndex32Buffer #-}
 
-draw :: Linear.MonadIO m => Word32 -> RenderPassCmd m
-draw vertexCount = unsafeRenderPassCmd_ (\buf -> Vk.cmdDraw buf vertexCount 1 0 0)
+draw :: Linear.MonadIO m => Word32 -> Word32 -> Word32 -> Word32 -> RenderPassCmd m
+draw vertexCount firstVertex instanceCount firstInstance = unsafeRenderPassCmd_ (\buf -> Vk.cmdDraw buf vertexCount instanceCount firstVertex firstInstance)
 {-# INLINE draw #-}
 
-drawIndexed :: Linear.MonadIO m => Word32 -> RenderPassCmd m
-drawIndexed ixCount = unsafeRenderPassCmd_ $ \buf -> Vk.cmdDrawIndexed buf ixCount 1 0 0 0
+drawIndexed :: Linear.MonadIO m => Word32 -> Word32 -> Word32 -> Word32 -> Int32 -> RenderPassCmd m
+drawIndexed indexCount firstIndex instanceCount firstInstance vertexOffset = unsafeRenderPassCmd_ $ \buf -> Vk.cmdDrawIndexed buf indexCount instanceCount firstIndex vertexOffset firstInstance
 {-# INLINE drawIndexed #-}
 
 copyFullBuffer :: Linear.MonadIO m => Vk.Buffer ⊸ Vk.Buffer ⊸ Vk.DeviceSize -> CommandM m (Vk.Buffer, Vk.Buffer)
@@ -430,20 +437,39 @@ transitionImageLayout img srcLayout dstLayout =
 -- Ultimately, I think it will be about a good abstraction for issuing/batching
 -- draw call.
 
+data SimpleMeshOpts = SimpleMeshOpts {
+  -- Nothing means use the vertex count of the mesh
+  vertexCount :: Maybe Word32
+  , firstVertex :: Word32
+  , instanceCount :: Word32
+  , firstInstance :: Word32
+  }
 
-drawVertexBuffer :: Linear.MonadIO m => VertexBuffer ⊸ RenderPassCmdM m VertexBuffer
-drawVertexBuffer (VertexBuffer (DeviceLocalBuffer buf mem) nverts) = Linear.do
+data IndexedMeshOpts = IndexedMeshOpts {
+  indexCount :: Maybe Word32
+  , firstIndex :: Word32
+  , instanceCount :: Word32
+  , firstInstance :: Word32
+  , vertexOffset :: Int32
+  }
+
+drawVertexBuffer :: Linear.MonadIO m => IORef SimpleMeshOpts -> VertexBuffer ⊸ RenderPassCmdM m VertexBuffer
+drawVertexBuffer o (VertexBuffer (DeviceLocalBuffer buf mem) nv) = Linear.do
+  Ur o' <- Linear.liftSystemIOU $ readIORef o
+  let nverts = fromMaybe nv o'.vertexCount
   let offsets = V.make 0
   buffers' <- bindVertexBuffers 0 (V.make buf :: V.V 1 Vk.Buffer) offsets
-  draw nverts
+  draw (fromMaybe nverts o'.vertexCount) o'.firstVertex o'.instanceCount o'.firstInstance
   pure (VertexBuffer (DeviceLocalBuffer (V.elim (\x -> x) buffers') mem) nverts)
 
-drawVertexBufferIndexed :: Linear.MonadIO m => VertexBuffer ⊸ Index32Buffer ⊸ RenderPassCmdM m (VertexBuffer, Index32Buffer)
-drawVertexBufferIndexed (VertexBuffer (DeviceLocalBuffer vbuf mem) nverts) (Index32Buffer (DeviceLocalBuffer ibuf imem) nixs) = Linear.do
+drawVertexBufferIndexed :: Linear.MonadIO m => IORef IndexedMeshOpts -> VertexBuffer ⊸ Index32Buffer ⊸ RenderPassCmdM m (VertexBuffer, Index32Buffer)
+drawVertexBufferIndexed o (VertexBuffer (DeviceLocalBuffer vbuf mem) nverts) (Index32Buffer (DeviceLocalBuffer ibuf imem) nix) = Linear.do
+  (Ur o') <- Linear.liftSystemIOU $ readIORef o
+  let nixs = fromMaybe nix o'.indexCount
   let offsets = V.make 0
   buffers' <- bindVertexBuffers 0 (V.make vbuf) offsets
   ibuf'    <- bindIndex32Buffer ibuf 0
-  drawIndexed nixs
+  drawIndexed nixs o'.firstIndex o'.instanceCount o'.firstInstance o'.vertexOffset
   pure ( VertexBuffer (DeviceLocalBuffer (V.elim (\x -> x) buffers') mem) nverts
        , Index32Buffer (DeviceLocalBuffer ibuf' imem) nixs
        )

--- a/ghengin/ghengin-geometry/Ghengin/Geometry/Obj.hs
+++ b/ghengin/ghengin-geometry/Ghengin/Geometry/Obj.hs
@@ -39,7 +39,7 @@ loadObjMesh :: (CompatibleMesh ts π, CompatibleVertex '[Vec3, Vec3] π)
              ⊸ PropertyBindings ts
             -- ^ These must NOT be added after creating the mesh.
             -- The property bindings need to set when creating it.
-             ⊸ Renderer (Mesh '[Vec3, Vec3] ts, RenderPipeline π ps)
+             ⊸ Renderer (Mesh '[Vec3, Vec3] ts, RenderPipeline π ps, Ur (IORef SimpleMeshOpts))
 loadObjMesh filepath rp props = Linear.do
   Linear.liftSystemIOU (loadObjFile filepath) Linear.>>= \case
     Linear.Ur (Left err) -> Linear.do
@@ -56,7 +56,7 @@ createObjMesh :: (CompatibleMesh ts π, CompatibleVertex '[Vec3, Vec3] π)
                ⊸ PropertyBindings ts
               -- ^ These must NOT be added after creating the mesh.
               -- The property bindings need to set when creating it.
-               ⊸ Renderer (Mesh '[Vec3, Vec3] ts, RenderPipeline π ps)
+               ⊸ Renderer (Mesh '[Vec3, Vec3] ts, RenderPipeline π ps, Ur (IORef SimpleMeshOpts))
 createObjMesh wavefrontObj rp props =
   let
       locs    = V.map getLoc    $ wavefrontObj.objLocations

--- a/ghengin/ghengin-geometry/Ghengin/Geometry/Sphere.hs
+++ b/ghengin/ghengin-geometry/Ghengin/Geometry/Sphere.hs
@@ -6,10 +6,11 @@
 module Ghengin.Geometry.Sphere where
 
 import Prelude
-import Ghengin.Core.Prelude (GHList(..), Int32)
+import Ghengin.Core.Prelude (GHList(..), Int32, Ur(..))
 import Control.Monad
 import Geomancy.Vec3
 
+import Data.IORef
 import Ghengin.Core.Type.Compatible
 import Ghengin.Core.Renderer
 import Ghengin.Core.Render.Pipeline
@@ -87,7 +88,7 @@ newUnitCubeSphereFace topf res =
 newCubeSphereMesh :: (CompatibleMesh '[] π, CompatibleVertex [Vec3, Vec3] π)
               => RenderPipeline π bs
               -> Int -- ^ Resolution
-              -> Renderer (Mesh [Vec3, Vec3] '[], RenderPipeline π bs)
+              -> Renderer (Mesh [Vec3, Vec3] '[], RenderPipeline π bs, Ur (IORef IndexedMeshOpts))
 newCubeSphereMesh pi res =
   let UnitSphere vs is = newUnitCubeSphere res
    in createMeshWithIxsSV pi GHNil vs is


### PR DESCRIPTION
Hello!

I finally needed instancing to continue development, so I decided to try implementing it.

The root of the problem is to give the user access to a mutable variable, which when edited sets the `instanceCount` argument all the way down in the `draw` function here: https://github.com/alt-romes/ghengin/blob/2c15c1f2e1d69bfab46391bc4b518b19664206f6/ghengin-core/ghengin-vulkan/Ghengin/Vulkan/Renderer/Command.hs#L297

As you can see, currently it's hardcoded to `1`.

However, as I tried a few solutions, I noticed that there were several other useful variables down there in the `draw` function that I might need to change in the future, so I decided to include them all in one big record.

```haskell
data SimpleMeshOpts = SimpleMeshOpts {
  -- Nothing means use the vertex count of the mesh
  vertexCount :: Maybe Word32
  , firstVertex :: Word32
  , instanceCount :: Word32
  , firstInstance :: Word32
  }

data IndexedMeshOpts = IndexedMeshOpts {
  indexCount :: Maybe Word32
  , firstIndex :: Word32
  , instanceCount :: Word32
  , firstInstance :: Word32
  , vertexOffset :: Int32
  }
```
These records can be edited through an `IORef` that you get access to via the createMesh function:
```haskell
(fooMesh, fooPipeline, Ur fooOpt) <- Gmesh.createMesh pipeline ...

Ur () <- liftSystemIOU $ writeIORef fooOpt ((Gmesh.simpleMeshOptsDef{instanceCount = length entities}) :: SimpleMeshOpts)
```

This new variable can be safely ignored, and it will then revert back to the settings hardcoded currently, that is one instance, 0 as `firstIndex`, etc:
```
(fooMesh, fooPipeline, Ur _) <- Gmesh.createMesh pipeline ...
```

This does break the current API. I updated the examples, but I might have fixed something. 

I also added an `Array` ShaderData instance, as they are pretty much essential to do instanced rendering. As noted in the comments next to it, I'm not sure whether it's a proper ShaderData instance, but it works for now. There was also a small bug with the `Matrix` and `Vector` type that prevented their contents from expanding with recursive `FirType` calls.

I haven't done much testing yet, but it works perfectly in my game.

I suppose this adds some overhead in the form of one IORef read per draw. I'm not sure how that could be improved. I assume GHC optimizes this to some extent if you choose not to change it.

Thoughts?